### PR TITLE
Remove array-find-index

### DIFF
--- a/Libraries/NetInfo/NetInfo.web.js
+++ b/Libraries/NetInfo/NetInfo.web.js
@@ -9,7 +9,6 @@
 'use strict';
 
 import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
-import findIndex from 'array-find-index';
 import invariant from 'fbjs/lib/invariant';
 
 const connection =
@@ -88,7 +87,7 @@ const NetInfo = {
         type
       );
 
-      const listenerIndex = findIndex(connectionListeners, pair => pair[0] === handler);
+      const listenerIndex = connectionListeners.findIndex(pair => pair[0] === handler);
       invariant(
         listenerIndex !== -1,
         'Trying to remove NetInfo connection listener for unregistered handler'


### PR DESCRIPTION
Used `array-find-index` but not found in dependencies section of `package.json`, replace with Array.prototype.findIndex.