### PR TITLE
Add function EventEmitter.removeListener, compatible react-native EventEmitter path

### DIFF
--- a/Libraries/EventEmitter/EventEmitter.js
+++ b/Libraries/EventEmitter/EventEmitter.js
@@ -1,0 +1,2 @@
+var EventEmitter = require('../vendor/EventEmitter');
+module.exports = EventEmitter;

--- a/Libraries/vendor/emitter/EventEmitter.js
+++ b/Libraries/vendor/emitter/EventEmitter.js
@@ -83,6 +83,15 @@ class EventEmitter {
   }
 
   /**
+   * Remove a specific listener.
+   *
+   * @param {Object} listener -  Created by addListener
+   */
+  removeListener(listener: Object) {
+    this._subscriber.removeSubscription(listener)
+  }
+
+  /**
    * Removes all of the registered listeners, including those registered as
    * listener maps.
    *


### PR DESCRIPTION
Compatible react-native-root-siblings (maybe other libraries).

At https://github.com/magicismight/react-native-root-siblings/blob/master/lib/AppRegistryInjection.js#L4, it depends path `'react-native/Libraries/EventEmitter/EventEmitter'`.

At https://github.com/magicismight/react-native-root-siblings/blob/master/lib/AppRegistryInjection.js#L36, it depends EventEmitter.removeListener.