### PR TITLE
Upgrade react-mixin to avoid assigning this.state in componentWillMount

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "object-assign": "3.0.0",
     "promise": "7.0.4",
     "prop-types": "^15.5.10",
-    "react-mixin": "^3.1.0",
+    "react-mixin": "3.1.0",
     "react-timer-mixin": "0.13.2",
     "rebound": "0.0.13",
     "webpack": "1.13.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "object-assign": "3.0.0",
     "promise": "7.0.4",
     "prop-types": "^15.5.10",
-    "react-mixin": "3.0.3",
+    "react-mixin": "^3.1.0",
     "react-timer-mixin": "0.13.2",
     "rebound": "0.0.13",
     "webpack": "1.13.2",


### PR DESCRIPTION
Too many warnings:

Warning: XComponent.componentWillMount(): Assigning directly to this.state is deprecated (except inside a component's constructor). Use setState instead.

See https://github.com/brigand/react-mixin/issues/52
